### PR TITLE
Improvements to Read the Docs integration

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -37,4 +37,4 @@ jobs:
         run: poetry install -v
         if: steps.cached-poetry.outputs.cache-hit != 'true'
       - name: Run Tox test suite
-        run: poetry run tox -c .toxrc -e "precommit,docs,{py}-{coverage,nocoverage}"
+        run: poetry run tox -c .toxrc -e "precommit,{py}-{coverage,nocoverage}"

--- a/.toxrc
+++ b/.toxrc
@@ -2,7 +2,6 @@
 isolated_build = true
 envlist = 
    precommit,
-   docs,
    {py}-{coverage,nocoverage}
 ignore_basepython_conflict = true
 
@@ -20,11 +19,3 @@ commands =
    poetry --version
    poetry version
    poetry run pre-commit run --all-files --show-diff-on-failure
-
-[testenv:docs]
-whitelist_externals = poetry
-changedir = docs
-commands =
-   poetry --version
-   poetry version
-   poetry run sphinx-build -b html -d _build/doctrees . _build/html

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -534,7 +534,7 @@ been making changes to the demo - or if it crashed or was interrupted - and the
 
 ### Documentation
 
-Documentation at [Read the Docs](https://apologies-server.readthedocs.io/en/latest/)
+Documentation at [Read the Docs](https://apologies-server.readthedocs.io/en/stable/)
 is generated via a GitHub hook each time code is pushed to master.  So, there
 is no formal release process for the documentation.
 

--- a/PyPI.md
+++ b/PyPI.md
@@ -4,13 +4,13 @@
 ![](https://img.shields.io/pypi/wheel/apologiesserver.svg)
 ![](https://img.shields.io/pypi/pyversions/apologiesserver.svg)
 ![](https://github.com/pronovic/apologies-server/workflows/Test%20Suite/badge.svg)
-![](https://readthedocs.org/projects/apologies-server/badge/?version=latest&style=flat)
+![](https://readthedocs.org/projects/apologies-server/badge/?version=stable&style=flat)
 
 [Apologies Server](https://github.com/pronovic/apologies-server) is a [Websocket](https://en.wikipedia.org/wiki/WebSocket) server interface used to interactively play a multi-player game using the [Apologies](https://github.com/pronovic/apologies) library.  The Apologies library implements a game similar to the [Sorry](https://en.wikipedia.org/wiki/Sorry!_(game)) board game.  
 
-It was written as a learning exercise and technology demonstration effort, and serves as a complete example of how to manage a modern (circa 2020) Python project, including style checks, code formatting, integration with IntelliJ, [CI builds at GitHub](https://github.com/pronovic/apologies-server/actions), and integration with [PyPI](https://pypi.org/project/apologiesserver/) and [Read the Docs](https://apologies-server.readthedocs.io/en/latest/).  
+It was written as a learning exercise and technology demonstration effort, and serves as a complete example of how to manage a modern (circa 2020) Python project, including style checks, code formatting, integration with IntelliJ, [CI builds at GitHub](https://github.com/pronovic/apologies-server/actions), and integration with [PyPI](https://pypi.org/project/apologiesserver/) and [Read the Docs](https://apologies-server.readthedocs.io/en/stable/).  
 
-See the [documentation](https://apologies-server.readthedocs.io/en/latest/design.html) for notes about the public interface and the event model.
+See the [documentation](https://apologies-server.readthedocs.io/en/stable/design.html) for notes about the public interface and the event model.
 
 As of this writing, the published PyPI project does not include a script to run
 the server. The only way to run it is from the codebase, for local testing. See

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 ![](https://img.shields.io/pypi/wheel/apologiesserver.svg)
 ![](https://img.shields.io/pypi/pyversions/apologiesserver.svg)
 ![](https://github.com/pronovic/apologies-server/workflows/Test%20Suite/badge.svg)
-![](https://readthedocs.org/projects/apologies-server/badge/?version=latest&style=flat)
+![](https://readthedocs.org/projects/apologies-server/badge/?version=stable&style=flat)
 
 [Apologies Server](https://github.com/pronovic/apologies-server) is a [Websocket](https://en.wikipedia.org/wiki/WebSocket) server interface used to interactively play a multi-player game using the [Apologies](https://github.com/pronovic/apologies) library.  The Apologies library implements a game similar to the [Sorry](https://en.wikipedia.org/wiki/Sorry!_(game)) board game.
 
-It was written as a learning exercise and technology demonstration effort, and serves as a complete example of how to manage a modern (circa 2020) Python project, including style checks, code formatting, integration with IntelliJ, [CI builds at GitHub](https://github.com/pronovic/apologies-server/actions), and integration with [PyPI](https://pypi.org/project/apologiesserver/) and [Read the Docs](https://apologies-server.readthedocs.io/en/latest/).  
+It was written as a learning exercise and technology demonstration effort, and serves as a complete example of how to manage a modern (circa 2020) Python project, including style checks, code formatting, integration with IntelliJ, [CI builds at GitHub](https://github.com/pronovic/apologies-server/actions), and integration with [PyPI](https://pypi.org/project/apologiesserver/) and [Read the Docs](https://apologies-server.readthedocs.io/en/stable/).  
 
 Developer documentation is found in [DEVELOPER.md](DEVELOPER.md).  See that
 file for notes about how the code is structured, how to set up a development

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,8 +15,8 @@ Release v\ |version|
 .. image:: https://github.com/pronovic/apologies-server/workflows/Test%20Suite/badge.svg
     :target: https://github.com/pronovic/apologies-server
 
-.. image:: https://readthedocs.org/projects/apologies-server/badge/?version=latest&style=flat
-    :target: https://apologies-server.readthedocs.io/en/latest/
+.. image:: https://readthedocs.org/projects/apologies-server/badge/?version=stable&style=flat
+    :target: https://apologies-server.readthedocs.io/en/stable/
 
 
 ApologiesServer_  is a Websocket_ server interface used to interactively play a

--- a/run
+++ b/run
@@ -112,7 +112,7 @@ run_tox() {
       run_install
    fi
 
-   poetry run tox -c .toxrc -e "precommit,docs,{py}-{coverage,nocoverage}"
+   poetry run tox -c .toxrc -e "precommit,{py}-{coverage,nocoverage}"
 }
 
 # Build the Sphinx documentation for apologies-server.readthedocs.io


### PR DESCRIPTION
Read the Docs now offers a config option to build pull requests. The generated documentation is removed 90 days after the branch is deleted. Since I've run into cases where the docs built correctly in the Tox test suite but failed at Read the Docs itself, it seems better to rely on the official Read the Docs build as the merge gate.

At the same time, I adjusted configuration to properly use the stable branch at Read the Docs (which always points at the most recent tagged release), so I converted all of the links to use that URL.