### PR TITLE
Update to Pytest v9.0.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ docs = [
 [dependency-groups]
 dev = [
    "ruff (>=0.12.10,<1.0.0)",
-   "pytest (>=9.0.2,<10.0.0)",
+   "pytest (>=9.0.3,<10.0.0)",
    "pytest-testdox (>=3.1.0,<4.0.0)",
    "pytest-cov (>=7.1.0,<8.0.0)",
    "prek (>=0.2.1,<1.0.0)",
@@ -88,7 +88,8 @@ show_missing = false
 precision = 0
 omit = [ "src/tests/*" ]
 
-[tool.pytest.ini_options]
+[tool.pytest]
+strict = true
 asyncio_mode = "strict"
 filterwarnings = [
     'error',  # turn all Python warnings into test failures, so they're hard to miss

--- a/uv.lock
+++ b/uv.lock
@@ -72,7 +72,7 @@ dev = [
     { name = "colorama", specifier = ">=0.4.6,<1.0.0" },
     { name = "mypy", specifier = ">=1.6.0,<2.0.0" },
     { name = "prek", specifier = ">=0.2.1,<1.0.0" },
-    { name = "pytest", specifier = ">=9.0.2,<10.0.0" },
+    { name = "pytest", specifier = ">=9.0.3,<10.0.0" },
     { name = "pytest-asyncio", specifier = ">=1.3.0,<2.0.0" },
     { name = "pytest-cov", specifier = ">=7.1.0,<8.0.0" },
     { name = "pytest-testdox", specifier = ">=3.1.0,<4.0.0" },
@@ -634,7 +634,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -643,9 +643,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Along with this update, I'm moving to native TOML configuration syntax, and enabling the new `strict` configuration option.  This also fixes a Dependabot warning about insecure temp file handling.  Based on [apologies PR #83](https://github.com/pronovic/apologies/pull/83).